### PR TITLE
Default sec group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -64,10 +64,10 @@ resource "aws_security_group_rule" "ingress" {
 
 resource "aws_security_group_rule" "egress" {
   count             = var.enabled && length(var.security_groups) == 0 ? 1 : 0
-  type              = "egress"
-  from_port         = 0
-  to_port           = 0
-  protocol          = "-1"
+  type              = "ingress"
+  from_port         = 2049
+  to_port           = 2049
+  protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = join("", aws_security_group.efs.*.id)
 }

--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ resource "aws_efs_mount_target" "default" {
   file_system_id  = join("", aws_efs_file_system.default.*.id)
   ip_address      = var.mount_target_ip_address
   subnet_id       = var.subnets[count.index]
-  security_groups = [length(var.security_groups) > 0 ? var.security_groups : join("", aws_security_group.efs.*.id)]
+  security_groups = length(var.security_groups) > 0 ? var.security_groups : [join("", aws_security_group.efs.*.id)]
 }
 
 resource "aws_security_group" "efs" {

--- a/main.tf
+++ b/main.tf
@@ -36,11 +36,11 @@ resource "aws_efs_mount_target" "default" {
   file_system_id  = join("", aws_efs_file_system.default.*.id)
   ip_address      = var.mount_target_ip_address
   subnet_id       = var.subnets[count.index]
-  security_groups = [join("", aws_security_group.efs.*.id)]
+  security_groups = [length(var.security_groups) > 0 ? var.security_groups : join("", aws_security_group.efs.*.id)]
 }
 
 resource "aws_security_group" "efs" {
-  count       = var.enabled ? 1 : 0
+  count       = var.enabled && length(var.security_groups) == 0 ? 1 : 0
   name        = format("%s-efs", module.label.id)
   description = "EFS Security Group"
   vpc_id      = var.vpc_id
@@ -53,7 +53,7 @@ resource "aws_security_group" "efs" {
 }
 
 resource "aws_security_group_rule" "ingress" {
-  count                    = var.enabled ? length(var.security_groups) : 0
+  count                    = var.enabled && length(var.security_groups) == 0 ? length(var.security_groups) : 0
   type                     = "ingress"
   from_port                = "2049" # NFS
   to_port                  = "2049"
@@ -63,7 +63,7 @@ resource "aws_security_group_rule" "ingress" {
 }
 
 resource "aws_security_group_rule" "egress" {
-  count             = var.enabled ? 1 : 0
+  count             = var.enabled && length(var.security_groups) == 0 ? 1 : 0
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/variables.tf
+++ b/variables.tf
@@ -49,6 +49,7 @@ variable "tags" {
 variable "security_groups" {
   type        = list(string)
   description = "Security group IDs to allow access to the EFS"
+  default     = []
 }
 
 variable "vpc_id" {


### PR DESCRIPTION
## what
- disabled default security group creating when var.security_groups supplied
- var.security_groups is not required parameter, but optional
- updated security group to allow all EFS/NFS traffic


## why
- there is no need of yet another security group if custom SG(s) provided
- default SG only created when no security_groups or security_groups = [] is supplied, therefore it's not required parameter anymore
- updated default SG rule as EFS should only have NSF/2049 port allowed for ingress traffic


## references
n/a

